### PR TITLE
fix: use the list from CountriesContext 

### DIFF
--- a/src/context/PaginationContext.jsx
+++ b/src/context/PaginationContext.jsx
@@ -1,10 +1,10 @@
-import React, { createContext, useState } from 'react';
-import useFetchCountries from '../hook/useFetchCountries';
+import React, { createContext, useState, useContext } from 'react';
+import CountriesContext from './CountriesContext';
 
 const PaginationContext = createContext();
 
 export function PaginationProvider({ children }) {
-  const { list } = useFetchCountries();
+  const { list } = useContext(CountriesContext);
 
   const [countriesPerPage] = useState(12);
   const [currentPage, setCurrentPage] = useState(1);


### PR DESCRIPTION
The list was not updating when the user selects a region from the dropdown or types a country name in the input bar.

The root cause:
the list was from the useFetchCountries hook and this is why the list was not updating since the hook `doesn't` contain functions for dropdown and search bar. 

The solution:
Using the list from CountriesContext instead since it includes both search and dropdown functions.